### PR TITLE
Fix line tag text color changing with dark mode

### DIFF
--- a/lib/station_display.dart
+++ b/lib/station_display.dart
@@ -59,7 +59,7 @@ class LineTag extends StatelessWidget {
         color: lineType.color,
         borderRadius: BorderRadius.circular(3)
       ),
-      child: Text(lineName),
+      child: Text(lineName, style: const TextStyle(color: Colors.white),),
     );
   }
 }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -7,7 +7,7 @@ publish_to: 'none'
 # Increment MINOR when introducing new features
 # Increment PATCH when fixing bugs/refactoring
 # Changes that do not modify code (e.g. README) should not increment the version number
-version: 0.0.1
+version: 0.0.2
 
 environment:
   sdk: ^3.5.3


### PR DESCRIPTION
Fixes line tags being hard to read without dark mode. In light mode, it changes to a dark text color, making the tags hard to read. Instead, it should be locked to white.