### PR TITLE
Fix refreshing on home_page and station_departures

### DIFF
--- a/lib/home_page.dart
+++ b/lib/home_page.dart
@@ -3,7 +3,6 @@ import 'package:departures/services/vbb_api.dart';
 import 'package:departures/services/nearby_stations.dart';
 import 'package:departures/station_display.dart';
 import 'package:flutter/material.dart';
-import 'package:flutter/rendering.dart';
 import 'package:flutter/scheduler.dart';
 import 'package:flutter/services.dart';
 import 'package:location/location.dart';

--- a/lib/home_page.dart
+++ b/lib/home_page.dart
@@ -3,6 +3,7 @@ import 'package:departures/services/vbb_api.dart';
 import 'package:departures/services/nearby_stations.dart';
 import 'package:departures/station_display.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter/rendering.dart';
 import 'package:flutter/scheduler.dart';
 import 'package:flutter/services.dart';
 import 'package:location/location.dart';
@@ -96,10 +97,21 @@ class _HomePageState extends State<HomePage> {
             onRefresh: _updateNearbyStations,
             key: _refreshIndicatorKey,
             child: _nearbyStations.isEmpty
-              ? Center(
-                child: Text(
-                  emptyListExplanation,
-                  textAlign: TextAlign.center,
+              ? LayoutBuilder(
+                builder: (context, constraints) => SingleChildScrollView(
+                  physics: const AlwaysScrollableScrollPhysics(),
+                  child: ConstrainedBox(
+                    constraints: BoxConstraints(
+                      minWidth: constraints.maxWidth,
+                      minHeight: constraints.maxHeight,
+                    ),
+                    child: Center(
+                      child: Text(
+                        emptyListExplanation,
+                        textAlign: TextAlign.center,
+                      ),
+                    ),
+                  ),
                 ),
               )
               : ListView.builder(

--- a/lib/station_departures.dart
+++ b/lib/station_departures.dart
@@ -58,21 +58,21 @@ class _StationDeparturesState extends State<StationDepartures> {
   Widget build(BuildContext context) {
     stationId = widget.stationId;
 
-    return RefreshIndicator(
-      onRefresh: _updateDepartures,
-      key: _refreshIndicatorKey,
-      child: Column(
-        mainAxisAlignment: MainAxisAlignment.start,
-        crossAxisAlignment: CrossAxisAlignment.start,
-        children: [
-          SafeArea(
-            child: Padding(
-              padding: const EdgeInsets.only(left: 16, right: 16, bottom: 4),
-              child: Text(widget.stationName, style: Theme.of(context).textTheme.headlineSmall,),
-            ),
+    return Column(
+      mainAxisAlignment: MainAxisAlignment.start,
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        SafeArea(
+          child: Padding(
+            padding: const EdgeInsets.only(left: 16, right: 16, bottom: 4),
+            child: Text(widget.stationName, style: Theme.of(context).textTheme.headlineSmall,),
           ),
-          const Divider(indent: 16, endIndent: 16,),
-          Expanded(
+        ),
+        const Divider(indent: 16, endIndent: 16,),
+        Expanded(
+          child: RefreshIndicator(
+            onRefresh: _updateDepartures,
+            key: _refreshIndicatorKey,
             child: ListView.builder(
               itemCount: _departures.length,
               itemBuilder: (context, index) {
@@ -87,8 +87,8 @@ class _StationDeparturesState extends State<StationDepartures> {
               }
             ),
           ),
-        ],
-      ),
+        ),
+      ],
     );
   }
 }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -7,7 +7,7 @@ publish_to: 'none'
 # Increment MINOR when introducing new features
 # Increment PATCH when fixing bugs/refactoring
 # Changes that do not modify code (e.g. README) should not increment the version number
-version: 0.0.3
+version: 0.0.4
 
 environment:
   sdk: ^3.5.3


### PR DESCRIPTION
Fixes being unable to refresh the list of nearby stations if the list is empty (e.g. after an API error). Also fixes the RefreshIndicator being shown over the title of the StationDepartures page.