### PR TITLE
Update CI configuration for pull requests to main branch

### DIFF
--- a/.github/workflows/version-check.yml
+++ b/.github/workflows/version-check.yml
@@ -24,7 +24,7 @@ jobs:
       - name: Get current version from pubspec.yaml
         id: current_version
         run: |
-          current_version=$(grep '^version: ' pubspec.yaml | awk '{print $2}')
+          current_version=$(grep '^version: ' pubspec.yaml | awk '{print $2}' | sed 's/+.*//')
           echo "Current version is $current_version"
           echo "current_version=$current_version" >> $GITHUB_ENV
 

--- a/.github/workflows/version-check.yml
+++ b/.github/workflows/version-check.yml
@@ -3,6 +3,7 @@ name: Check Flutter Version Increment on PR
 on:
   pull_request:
     types: [opened, synchronize]
+    branches: main
 
 jobs:
   version-check:


### PR DESCRIPTION
Adjust CI to only run on pull requests targeting the main branch and remove the build number from the current version extraction.