### PR TITLE
Add toggle for actual/planned time display

### DIFF
--- a/lib/l10n/intl_de.arb
+++ b/lib/l10n/intl_de.arb
@@ -39,5 +39,8 @@
     "settingsOpenPrivacyPolicyButton": "Datenschutzrichtlinie öffnen",
     "settingsOpenDeviceSettingsButton": "Geräte Einstellungen öffnen",
     "searchBarPlaceholder": "Haltestelle eingeben",
-    "loadMore": "Mehr laden"
+    "loadMore": "Mehr laden",
+    "settingsShowActualTimeTitle": "Tatsächliche Zeit anzeigen",
+    "settingsShowActualTimeSubtitleOn": "Zeigt tatsächliche Zeit",
+    "settingsShowActualTimeSubtitleOff": "Zeigt geplante Zeit"
 }

--- a/lib/l10n/intl_en.arb
+++ b/lib/l10n/intl_en.arb
@@ -141,5 +141,17 @@
     "loadMore": "Load more",
     "@loadMore": {
         "description": "Button to load more nearby stations"
+    },
+    "settingsShowActualTimeTitle": "Show actual time",
+    "@settingsShowActualTimeTitle": {
+        "description": "Label for the show actual time toggle in the settings"
+    },
+    "settingsShowActualTimeSubtitleOn": "Showing actual time",
+    "@settingsShowActualTimeSubtitleOn": {
+        "description": "Subtitle when the show actual time toggle is on"
+    },
+    "settingsShowActualTimeSubtitleOff": "Showing planned time",
+    "@settingsShowActualTimeSubtitleOff": {
+        "description": "Subtitle when the show actual time toggle is off"
     }
 }

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,8 +1,9 @@
 import 'package:departures/pages/home_page.dart';
-import 'package:departures/provider/api_settings_provider.dart';
-import 'package:departures/provider/theme_settings_provider.dart';
 import 'package:departures/pages/search_page.dart';
 import 'package:departures/pages/settings_page.dart';
+import 'package:departures/provider/api_settings_provider.dart';
+import 'package:departures/provider/theme_settings_provider.dart';
+import 'package:departures/provider/time_display_settings_provider.dart';
 import 'package:dynamic_color/dynamic_color.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
@@ -15,6 +16,7 @@ void main() {
       providers: [
         ChangeNotifierProvider(create: (_) => ThemeProvider()),
         ChangeNotifierProvider(create: (_) => ApiSettingsProvider()),
+        ChangeNotifierProvider(create: (_) => TimeDisplaySettingsProvider()),
       ],
       child: const DeparturesApp()
     )

--- a/lib/pages/settings_page.dart
+++ b/lib/pages/settings_page.dart
@@ -1,6 +1,7 @@
 import 'package:departures/provider/api_settings_provider.dart';
 import 'package:departures/enums/app_theme_modes.dart';
 import 'package:departures/provider/theme_settings_provider.dart';
+import 'package:departures/provider/time_display_settings_provider.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_gen/gen_l10n/app_localizations.dart';
 import 'package:geolocator/geolocator.dart';
@@ -106,6 +107,20 @@ class _SettingsPageState extends State<SettingsPage> with AutomaticKeepAliveClie
                       },
                     );
                   }
+                ),
+              ),
+              Consumer<TimeDisplaySettingsProvider>(
+                builder: (context, timeDisplayProvider, child) => ListTile(
+                  title: Text(appLocalizations.settingsShowActualTimeTitle),
+                  subtitle: timeDisplayProvider.showActualTime
+                    ? Text(appLocalizations.settingsShowActualTimeSubtitleOn)
+                    : Text(appLocalizations.settingsShowActualTimeSubtitleOff),
+                  trailing: Switch(
+                    value: timeDisplayProvider.showActualTime,
+                    onChanged: (value) {
+                      timeDisplayProvider.setShowActualTime(value);
+                    },
+                  ),
                 ),
               ),
               const Divider(

--- a/lib/provider/time_display_settings_provider.dart
+++ b/lib/provider/time_display_settings_provider.dart
@@ -1,0 +1,34 @@
+import 'package:flutter/material.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+class TimeDisplaySettingsProvider with ChangeNotifier {
+  bool _showActualTime = true;
+  bool get showActualTime => _showActualTime;
+
+  TimeDisplaySettingsProvider() {
+    loadTimeDisplayPreferences();
+  }
+
+  Future<void> loadTimeDisplayPreferences() async {
+    SharedPreferences prefs = await SharedPreferences.getInstance();
+    bool? showActualTime = prefs.getBool("showActualTime");
+
+    if (showActualTime != null) {
+      _showActualTime = showActualTime;
+    }
+
+    notifyListeners();
+  }
+
+  Future<void> saveTimeDisplayPreference(bool showActualTime) async {
+    _showActualTime = showActualTime;
+    notifyListeners();
+
+    SharedPreferences prefs = await SharedPreferences.getInstance();
+    prefs.setBool('showActualTime', showActualTime);
+  }
+
+  void setShowActualTime(bool showActualTime) {
+    saveTimeDisplayPreference(showActualTime);
+  }
+}

--- a/lib/widgets/station_departures.dart
+++ b/lib/widgets/station_departures.dart
@@ -1,5 +1,6 @@
 import 'dart:async';
 
+import 'package:departures/provider/time_display_settings_provider.dart';
 import 'package:departures/widgets/bus_display.dart';
 import 'package:departures/enums/line_types.dart';
 import 'package:departures/services/departure.dart';
@@ -7,6 +8,7 @@ import 'package:departures/services/api.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/scheduler.dart';
 import 'package:flutter_gen/gen_l10n/app_localizations.dart';
+import 'package:provider/provider.dart';
 
 class StationDepartures extends StatefulWidget {
   const StationDepartures({
@@ -32,6 +34,12 @@ class _StationDeparturesState extends State<StationDepartures> {
     });
   }
 
+  @override
+  void didChangeDependencies() {
+    super.didChangeDependencies();
+    _timeDisplaySettingsProvider = Provider.of<TimeDisplaySettingsProvider>(context);
+  }
+
   final GlobalKey<RefreshIndicatorState> _refreshIndicatorKey = GlobalKey<RefreshIndicatorState>();
 
   String stationId = "";
@@ -40,6 +48,15 @@ class _StationDeparturesState extends State<StationDepartures> {
   bool _isProgrammaticRefresh = false;
   int _duration = 30;
   TimeOfDay? _when;
+
+  late final TimeDisplaySettingsProvider _timeDisplaySettingsProvider;
+
+  DateTime getDisplayTime(Departure departure) {
+    final departureTimeString = _timeDisplaySettingsProvider.showActualTime
+      ? (departure.when ?? departure.plannedWhen!)
+      : departure.plannedWhen!;
+    return DateTime.parse(departureTimeString).toLocal();
+  }
 
   Future<void> _updateDepartures() async {
     if (_isProgrammaticRefresh) {
@@ -58,8 +75,8 @@ class _StationDeparturesState extends State<StationDepartures> {
 
     final departures = await VbbApi.getDeparturesAtStop(stationId, context, duration: _duration, when: _when);
     departures.sort((a, b) {
-      final timeA = DateTime.parse(a.when ?? a.plannedWhen!).toLocal();
-      final timeB = DateTime.parse(b.when ?? b.plannedWhen!).toLocal();
+      final timeA = getDisplayTime(a);
+      final timeB = getDisplayTime(b);
 
       if (timeA.isBefore(timeB)) {
         return -1;
@@ -158,13 +175,15 @@ class _StationDeparturesState extends State<StationDepartures> {
                   );
                 }
 
-                return BusDisplay(
-                  direction: _departures[index].direction!,
-                  line: _departures[index].line!.name!,
-                  lineType: LineType.values.byName(_departures[index].line!.product!),
-                  departureTime: DateTime.parse(_departures[index].when ?? _departures[index].plannedWhen!).toLocal(),
-                  delay: _departures[index].delay == null ? null : (_departures[index].delay! / 60).round(),
-                  cancelled: _departures[index].cancelled,
+                return Consumer<TimeDisplaySettingsProvider>(
+                  builder: (context, timeDisplayProvider, child) => BusDisplay(
+                    direction: _departures[index].direction!,
+                    line: _departures[index].line!.name!,
+                    lineType: LineType.values.byName(_departures[index].line!.product!),
+                    departureTime: getDisplayTime(_departures[index]),
+                    delay: _departures[index].delay == null ? null : (_departures[index].delay! / 60).round(),
+                    cancelled: _departures[index].cancelled,
+                  ),
                 );
               }
             ),


### PR DESCRIPTION
Introduce a toggle in the settings to switch between showing actual and planned departure times. Implement a provider to manage the toggle state and update the relevant UI components accordingly.