### PR TITLE
Fix crash on first load in station departures

### DIFF
--- a/lib/widgets/station_departures.dart
+++ b/lib/widgets/station_departures.dart
@@ -41,6 +41,7 @@ class _StationDeparturesState extends State<StationDepartures> {
   }
 
   final GlobalKey<RefreshIndicatorState> _refreshIndicatorKey = GlobalKey<RefreshIndicatorState>();
+  late TimeDisplaySettingsProvider _timeDisplaySettingsProvider;
 
   String stationId = "";
   List<Departure> _departures = [];
@@ -48,8 +49,6 @@ class _StationDeparturesState extends State<StationDepartures> {
   bool _isProgrammaticRefresh = false;
   int _duration = 30;
   TimeOfDay? _when;
-
-  late final TimeDisplaySettingsProvider _timeDisplaySettingsProvider;
 
   DateTime getDisplayTime(Departure departure) {
     final departureTimeString = _timeDisplaySettingsProvider.showActualTime


### PR DESCRIPTION
Resolve a crash that occurred due to the re-initialization of the 
(then final) TimeDisplaySettingsProvider.