### PR TITLE
Merge v2.2.2+17

### DIFF
--- a/lib/widgets/bus_display.dart
+++ b/lib/widgets/bus_display.dart
@@ -50,8 +50,8 @@ class BusDisplay extends StatelessWidget {
               style: delay == null
                 ? const TextStyle(color: Colors.grey)
                 : delay == 0
-                  ? const TextStyle(color: Colors.greenAccent)
-                  : const TextStyle(color: Colors.redAccent)
+                  ? const TextStyle(color: Colors.green, fontWeight: FontWeight.w500)
+                  : const TextStyle(color: Colors.red, fontWeight: FontWeight.w500)
             )
           ])
         ),

--- a/lib/widgets/station_departures.dart
+++ b/lib/widgets/station_departures.dart
@@ -41,6 +41,7 @@ class _StationDeparturesState extends State<StationDepartures> {
   }
 
   final GlobalKey<RefreshIndicatorState> _refreshIndicatorKey = GlobalKey<RefreshIndicatorState>();
+  late TimeDisplaySettingsProvider _timeDisplaySettingsProvider;
 
   String stationId = "";
   List<Departure> _departures = [];
@@ -48,8 +49,6 @@ class _StationDeparturesState extends State<StationDepartures> {
   bool _isProgrammaticRefresh = false;
   int _duration = 30;
   TimeOfDay? _when;
-
-  late final TimeDisplaySettingsProvider _timeDisplaySettingsProvider;
 
   DateTime getDisplayTime(Departure departure) {
     final departureTimeString = _timeDisplaySettingsProvider.showActualTime

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -7,7 +7,7 @@ publish_to: 'none'
 # Increment MINOR when introducing new features
 # Increment PATCH when fixing bugs/refactoring
 # Changes that do not modify code (e.g. README) should not increment the version number
-version: 2.2.1+16
+version: 2.2.2+17
 
 environment:
   sdk: ^3.5.3


### PR DESCRIPTION
This pull request includes several changes to the `lib/widgets` directory and a version update in `pubspec.yaml`. The most important changes are grouped by theme below:

### UI Updates:
* [`lib/widgets/bus_display.dart`](diffhunk://#diff-f9de32610cc253d46acc6ac0ed3775bed2bd2338a7d12e9837b2f1a111415025L53-R54): Updated the text style for delay display, changing green and red accent colors to green and red with a medium font weight.

### State Management:
* [`lib/widgets/station_departures.dart`](diffhunk://#diff-3a78faf5bd94c4b7d0ec837cf05c1af642ff329e40b4da047b45a0b1613c9cf4R44): Removed the redundant declaration of `_timeDisplaySettingsProvider` and initialized it earlier in the class. [[1]](diffhunk://#diff-3a78faf5bd94c4b7d0ec837cf05c1af642ff329e40b4da047b45a0b1613c9cf4R44) [[2]](diffhunk://#diff-3a78faf5bd94c4b7d0ec837cf05c1af642ff329e40b4da047b45a0b1613c9cf4L52-L53)

### Version Update:
* [`pubspec.yaml`](diffhunk://#diff-8b7e9df87668ffa6a04b32e1769a33434999e54ae081c52e5d943c541d4c0d25L10-R10): Incremented the version from `2.2.1+16` to `2.2.2+17`.

~ Copilot