### PR TITLE
Merge v2.3.4+22

### DIFF
--- a/pubspec.lock
+++ b/pubspec.lock
@@ -353,10 +353,10 @@ packages:
     dependency: "direct main"
     description:
       name: package_info_plus
-      sha256: "70c421fe9d9cc1a9a7f3b05ae56befd469fe4f8daa3b484823141a55442d858d"
+      sha256: "739e0a5c3c4055152520fa321d0645ee98e932718b4c8efeeb51451968fe0790"
       url: "https://pub.dev"
     source: hosted
-    version: "8.1.2"
+    version: "8.1.3"
   package_info_plus_platform_interface:
     dependency: transitive
     description:

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -162,10 +162,10 @@ packages:
     dependency: "direct dev"
     description:
       name: flutter_launcher_icons
-      sha256: "31cd0885738e87c72d6f055564d37fabcdacee743b396b78c7636c169cac64f5"
+      sha256: bfa04787c85d80ecb3f8777bde5fc10c3de809240c48fa061a2c2bf15ea5211c
       url: "https://pub.dev"
     source: hosted
-    version: "0.14.2"
+    version: "0.14.3"
   flutter_lints:
     dependency: "direct dev"
     description:

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -353,10 +353,10 @@ packages:
     dependency: "direct main"
     description:
       name: package_info_plus
-      sha256: "739e0a5c3c4055152520fa321d0645ee98e932718b4c8efeeb51451968fe0790"
+      sha256: b15fad91c4d3d1f2b48c053dd41cb82da007c27407dc9ab5f9aa59881d0e39d4
       url: "https://pub.dev"
     source: hosted
-    version: "8.1.3"
+    version: "8.1.4"
   package_info_plus_platform_interface:
     dependency: transitive
     description:

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -489,10 +489,10 @@ packages:
     dependency: "direct main"
     description:
       name: shared_preferences
-      sha256: c59819dacc6669a1165d54d2735a9543f136f9b3cec94ca65cea6ab8dffc422e
+      sha256: "688ee90fbfb6989c980254a56cb26ebe9bb30a3a2dff439a78894211f73de67a"
       url: "https://pub.dev"
     source: hosted
-    version: "2.4.0"
+    version: "2.5.1"
   shared_preferences_android:
     dependency: transitive
     description:

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -489,10 +489,10 @@ packages:
     dependency: "direct main"
     description:
       name: shared_preferences
-      sha256: a752ce92ea7540fc35a0d19722816e04d0e72828a4200e83a98cf1a1eb524c9a
+      sha256: c59819dacc6669a1165d54d2735a9543f136f9b3cec94ca65cea6ab8dffc422e
       url: "https://pub.dev"
     source: hosted
-    version: "2.3.5"
+    version: "2.4.0"
   shared_preferences_android:
     dependency: transitive
     description:

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -77,10 +77,10 @@ packages:
     dependency: "direct main"
     description:
       name: connectivity_plus
-      sha256: e0817759ec6d2d8e57eb234e6e57d2173931367a865850c7acea40d4b4f9c27d
+      sha256: "8a68739d3ee113e51ad35583fdf9ab82c55d09d693d3c39da1aebab87c938412"
       url: "https://pub.dev"
     source: hosted
-    version: "6.1.1"
+    version: "6.1.2"
   connectivity_plus_platform_interface:
     dependency: transitive
     description:

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -241,10 +241,10 @@ packages:
     dependency: "direct main"
     description:
       name: http
-      sha256: b9c29a161230ee03d3ccf545097fccd9b87a5264228c5d348202e0f0c28f9010
+      sha256: fe7ab022b76f3034adc518fb6ea04a82387620e19977665ea18d30a1cf43442f
       url: "https://pub.dev"
     source: hosted
-    version: "1.2.2"
+    version: "1.3.0"
   http_parser:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -7,7 +7,7 @@ publish_to: 'none'
 # Increment MINOR when introducing new features
 # Increment PATCH when fixing bugs/refactoring
 # Changes that do not modify code (e.g. README) should not increment the version number
-version: 2.3.3+21
+version: 2.3.4+22
 
 environment:
   sdk: ^3.6.0

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -18,7 +18,7 @@ dependencies:
 
   cupertino_icons: ^1.0.8
   intl: ^0.19.0
-  http: ^1.2.2
+  http: ^1.3.0
   permission_handler: ^11.3.1
   flutter_localizations:
     sdk: flutter

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -27,7 +27,7 @@ dependencies:
   package_info_plus: ^8.1.2
   url_launcher: ^6.3.1
   geolocator: ^13.0.1
-  connectivity_plus: ^6.1.1
+  connectivity_plus: ^6.1.2
   dynamic_color: ^1.7.0
   restart_app: ^1.3.2
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -22,7 +22,7 @@ dependencies:
   permission_handler: ^11.3.1
   flutter_localizations:
     sdk: flutter
-  shared_preferences: ^2.4.0
+  shared_preferences: ^2.5.1
   provider: ^6.1.2
   package_info_plus: ^8.1.4
   url_launcher: ^6.3.1

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -24,7 +24,7 @@ dependencies:
     sdk: flutter
   shared_preferences: ^2.4.0
   provider: ^6.1.2
-  package_info_plus: ^8.1.3
+  package_info_plus: ^8.1.4
   url_launcher: ^6.3.1
   geolocator: ^13.0.1
   connectivity_plus: ^6.1.2

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -36,7 +36,7 @@ dev_dependencies:
     sdk: flutter
 
   flutter_lints: ^5.0.0
-  flutter_launcher_icons: ^0.14.2
+  flutter_launcher_icons: ^0.14.3
 
 flutter:
   uses-material-design: true

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -22,7 +22,7 @@ dependencies:
   permission_handler: ^11.3.1
   flutter_localizations:
     sdk: flutter
-  shared_preferences: ^2.3.5
+  shared_preferences: ^2.4.0
   provider: ^6.1.2
   package_info_plus: ^8.1.3
   url_launcher: ^6.3.1

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -24,7 +24,7 @@ dependencies:
     sdk: flutter
   shared_preferences: ^2.3.5
   provider: ^6.1.2
-  package_info_plus: ^8.1.2
+  package_info_plus: ^8.1.3
   url_launcher: ^6.3.1
   geolocator: ^13.0.1
   connectivity_plus: ^6.1.2


### PR DESCRIPTION
This pull request includes updates to the `pubspec.yaml` file, focusing on version increments and dependency updates.

Version increment:

* [`pubspec.yaml`](diffhunk://#diff-8b7e9df87668ffa6a04b32e1769a33434999e54ae081c52e5d943c541d4c0d25L10-R10): Incremented the version from `2.3.3+21` to `2.3.4+22`.

Dependency updates:

* [`pubspec.yaml`](diffhunk://#diff-8b7e9df87668ffa6a04b32e1769a33434999e54ae081c52e5d943c541d4c0d25L21-R30): Updated the `http` dependency from `^1.2.2` to `^1.3.0`.
* [`pubspec.yaml`](diffhunk://#diff-8b7e9df87668ffa6a04b32e1769a33434999e54ae081c52e5d943c541d4c0d25L21-R30): Updated the `shared_preferences` dependency from `^2.3.5` to `^2.5.1`.
* [`pubspec.yaml`](diffhunk://#diff-8b7e9df87668ffa6a04b32e1769a33434999e54ae081c52e5d943c541d4c0d25L21-R30): Updated the `package_info_plus` dependency from `^8.1.2` to `^8.1.4`.
* [`pubspec.yaml`](diffhunk://#diff-8b7e9df87668ffa6a04b32e1769a33434999e54ae081c52e5d943c541d4c0d25L21-R30): Updated the `connectivity_plus` dependency from `^6.1.1` to `^6.1.2`.

Dev dependency updates:

* [`pubspec.yaml`](diffhunk://#diff-8b7e9df87668ffa6a04b32e1769a33434999e54ae081c52e5d943c541d4c0d25L39-R39): Updated the `flutter_launcher_icons` dev dependency from `^0.14.2` to `^0.14.3`.