### PR TITLE
chore: update copyright year

### DIFF
--- a/lib/pages/settings_page.dart
+++ b/lib/pages/settings_page.dart
@@ -260,7 +260,7 @@ class _SettingsPageState extends State<SettingsPage> {
               mainAxisAlignment: MainAxisAlignment.center,
               children: [
                 Text(
-                  "v${_packageInfo?.version ?? ""} - © drenkmann 2024",
+                  "v${_packageInfo?.version ?? ""} - © drenkmann 2025",
                   style: Theme.of(context)
                       .textTheme
                       .bodySmall!


### PR DESCRIPTION
Updates the copyright year on the settings page from 2024 to 2025.

Resolves #66 