### PR TITLE
Merge v2.3.10+28

### DIFF
--- a/.github/workflows/version-check.yml
+++ b/.github/workflows/version-check.yml
@@ -49,7 +49,8 @@ jobs:
           if [ "$current_version" = "$tag_version" ]; then
             echo "Version number has not increased!"
             exit 1
-          elif [ "$current_version" \< "$tag_version" ]; then
+          fi
+          if [[ $(printf '%s\n' "$current_version" "$tag_version" | sort -V | head -n1) == "$current_version" ]]; then
             echo "Current version is lower than the latest tag!"
             exit 1
           else

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2024 drenkmann
+Copyright (c) 2025 drenkmann
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/lib/pages/home_page.dart
+++ b/lib/pages/home_page.dart
@@ -29,6 +29,7 @@ class _HomePageState extends State<HomePage> {
   final GlobalKey<RefreshIndicatorState> _refreshIndicatorKey =
       GlobalKey<RefreshIndicatorState>();
 
+  final lineTypeNames = LineType.values.map((e) => e.name);
   List<Stop> _nearbyStations = [];
   String emptyListExplanation = "";
 
@@ -241,7 +242,6 @@ class _HomePageState extends State<HomePage> {
         }
 
         Map<String, LineType> lineTypes = {};
-        final lineTypeNames = LineType.values.map((e) => e.name);
         for (final line in _nearbyStations[index].lines!) {
           if (lineTypeNames.contains(line.product) && line.name != null) {
             if (lineTypes.containsKey(line.name!)) continue;

--- a/lib/pages/home_page.dart
+++ b/lib/pages/home_page.dart
@@ -241,9 +241,9 @@ class _HomePageState extends State<HomePage> {
         }
 
         Map<String, LineType> lineTypes = {};
+        final lineTypeNames = LineType.values.map((e) => e.name);
         for (final line in _nearbyStations[index].lines!) {
-          if (LineType.values.map((e) => e.name).contains(line.product) &&
-              line.name != null) {
+          if (lineTypeNames.contains(line.product) && line.name != null) {
             if (lineTypes.containsKey(line.name!)) continue;
             lineTypes[line.name!] = LineType.values.byName(line.product!);
           }

--- a/lib/pages/home_page.dart
+++ b/lib/pages/home_page.dart
@@ -269,6 +269,7 @@ class _HomePageState extends State<HomePage> {
                             .map((e) => e.name)
                             .contains(line.product) &&
                         line.name != null) {
+                      if (lineTypes.containsKey(line.name!)) continue;
                       lineTypes[line.name!] = LineType.values.byName(
                         line.product!,
                       );

--- a/lib/pages/search_page.dart
+++ b/lib/pages/search_page.dart
@@ -93,6 +93,7 @@ class _SearchPageState extends State<SearchPage> {
 
             for (final line in _stops[index - 1].lines!) {
               if (LineType.values.map((e) => e.name).contains(line.product)) {
+                if (lineTypes.containsKey(line.name!)) continue;
                 lineTypes[line.name!] = LineType.values.byName(line.product!);
               }
             }

--- a/lib/pages/search_page.dart
+++ b/lib/pages/search_page.dart
@@ -91,8 +91,9 @@ class _SearchPageState extends State<SearchPage> {
 
             Map<String, LineType> lineTypes = {};
 
+            final lineTypeNames = LineType.values.map((e) => e.name);
             for (final line in _stops[index - 1].lines!) {
-              if (LineType.values.map((e) => e.name).contains(line.product)) {
+              if (lineTypeNames.contains(line.product)) {
                 if (lineTypes.containsKey(line.name!)) continue;
                 lineTypes[line.name!] = LineType.values.byName(line.product!);
               }

--- a/lib/pages/search_page.dart
+++ b/lib/pages/search_page.dart
@@ -14,6 +14,7 @@ class SearchPage extends StatefulWidget {
 
 class _SearchPageState extends State<SearchPage> {
   List<Stop> _stops = [];
+  final lineTypeNames = LineType.values.map((e) => e.name);
 
   late TextEditingController _searchController;
   final GlobalKey<RefreshIndicatorState> _refreshIndicatorKey =
@@ -91,7 +92,6 @@ class _SearchPageState extends State<SearchPage> {
 
             Map<String, LineType> lineTypes = {};
 
-            final lineTypeNames = LineType.values.map((e) => e.name);
             for (final line in _stops[index - 1].lines!) {
               if (lineTypeNames.contains(line.product)) {
                 if (lineTypes.containsKey(line.name!)) continue;

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -7,7 +7,7 @@ publish_to: 'none'
 # Increment MINOR when introducing new features
 # Increment PATCH when fixing bugs/refactoring
 # Changes that do not modify code (e.g. README) should not increment the version number
-version: 2.3.9+27
+version: 2.3.10+28
 
 environment:
   sdk: ^3.9.2


### PR DESCRIPTION
- Fixes some lines being displayed in the bus color instead of their proper coloring
- Resolves #91

---------

This pull request refactors the `HomePage` and `SearchPage` logic for handling lists of stations and lines, improving code readability and preventing duplicate line entries. Additionally, it updates the copyright year and increments the project version.

**UI Refactoring and Code Quality Improvements:**

* Refactored the `HomePage` widget in `lib/pages/home_page.dart` by extracting the empty list and station list views into separate methods (`_buildEmptyListView` and `_buildStationListView`), resulting in cleaner and more maintainable code. [[1]](diffhunk://#diff-99b4adebf77b6d2c75348a97021a381af2516d97e7e4dfb63fdb02da87f97283L205-R221) [[2]](diffhunk://#diff-99b4adebf77b6d2c75348a97021a381af2516d97e7e4dfb63fdb02da87f97283R260-R289)
* Improved line deduplication in both `HomePage` and `SearchPage` by adding a check to skip lines that have already been added to the `lineTypes` map, preventing duplicate entries in the station and stop lists. [[1]](diffhunk://#diff-99b4adebf77b6d2c75348a97021a381af2516d97e7e4dfb63fdb02da87f97283L266-R248) [[2]](diffhunk://#diff-6f2633c8bc18d09bb871c5979b85ecb4e96763f5e62cd2bbda499869434f11b0R96)

**Project Maintenance:**

* Updated the copyright year in `LICENSE.md` from 2024 to 2025.
* Incremented the project version in `pubspec.yaml` from `2.3.9+27` to `2.3.10+28` to reflect these changes.

~Copilot